### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/template/template-export-textract.yml
+++ b/template/template-export-textract.yml
@@ -346,7 +346,7 @@ Resources:
         Variables:
           LOG_LEVEL: INFO
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 600
       Role:
         Fn::GetAtt:


### PR DESCRIPTION
CloudFormation templates in amazon-textract-comprehend-OCRimage-search-and-analyze have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.