### PR TITLE
Updating the Python runtime to new runtime (python3.9) as python 2.7 …

### DIFF
--- a/template/template-export-textract.yml
+++ b/template/template-export-textract.yml
@@ -104,7 +104,7 @@ Resources:
     Properties:
       Description: Dummy function, just logs the received event
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role:
         Fn::GetAtt:
         - ApplyNotificationFunctionRole


### PR DESCRIPTION
Updating the Python runtime to new runtime (python3.9) as python 2.7 is no longer supported in `template-export-textract.yml` file. Fixing issue #10

I tested this new cloud formation template and the stack was successfully created without any errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
